### PR TITLE
Support creating certificates in other regions.

### DIFF
--- a/docs/Certificate.md
+++ b/docs/Certificate.md
@@ -22,6 +22,7 @@ You can specify the following properties:
     "DomainName" - to create a certificate for (required).
     "ValidationMethod" - to validate the certificate with (required to be DNS).
     "ServiceToken" - pointing to the function implementing this resource (required).
+    "Region" - region name where the certificate should be created, e.g. "us-east-1" (optional).
 
 For all other properties, check out [AWS::CertificateManager::Certificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html).
  

--- a/src/certificate_dns_record_provider.py
+++ b/src/certificate_dns_record_provider.py
@@ -7,7 +7,6 @@ from cfn_resource_provider import ResourceProvider
 
 logger = logging.getLogger()
 
-acm = boto3.client('acm')
 lmbda = boto3.client('lambda')
 
 
@@ -33,6 +32,8 @@ class CertificateDNSRecordProvider(ResourceProvider):
     @property
     def certificate(self):
         result = None
+        region = self.certificate_arn.split(':')[3]
+        acm = boto3.client('acm', region_name=region)
         try:
             response = acm.describe_certificate(CertificateArn=self.certificate_arn)
             result = Certificate(response["Certificate"])

--- a/src/certificate_provider.py
+++ b/src/certificate_provider.py
@@ -9,8 +9,6 @@ from cfn_resource_provider import ResourceProvider
 
 logger = logging.getLogger()
 
-acm = boto3.client('acm')
-
 
 class CertificateProvider(ResourceProvider):
     """
@@ -51,6 +49,8 @@ class CertificateProvider(ResourceProvider):
 
     def request_certificate(self):
         arguments = self.properties.copy()
+        region = arguments.pop('Region', None)
+        acm = boto3.client('acm', region_name=region)
         if 'ServiceToken' in arguments:
             del arguments['ServiceToken']
 
@@ -73,6 +73,8 @@ class CertificateProvider(ResourceProvider):
                     return self.request_certificate()
             elif changed_properties and len(changed_properties) == 1 and changed_properties[0] == 'Options':
                 try:
+                    region = self.properties.get('Region')
+                    acm = boto3.client('acm', region_name=region)
                     acm.update_certificate_options(CertificateArn=self.physical_resource_id, Options=self.get('Options'))
                 except ClientError as error:
                     self.fail('{}'.format(error))
@@ -89,6 +91,8 @@ class CertificateProvider(ResourceProvider):
             return
 
         try:
+            region = self.properties.get('Region')
+            acm = boto3.client('acm', region_name=region)
             response = acm.delete_certificate(CertificateArn=self.physical_resource_id)
         except ClientError as error:
             self.success('Ignore failure to delete certificate {}'.format(error))

--- a/src/issued_certificate_provider.py
+++ b/src/issued_certificate_provider.py
@@ -6,7 +6,6 @@ import json
 
 from certificate_dns_record_provider import CertificateDNSRecordProvider, PreConditionFailed
 
-acm = boto3.client('acm')
 lmbda = boto3.client('lambda')
 
 


### PR DESCRIPTION
This allows us to create certificates suitable for API Gateway (they have to be in us-east-1) in the same stack as the other infrastructure required to support the API.