### PR TITLE
Fixes to dockerfile and provider

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -4,6 +4,8 @@ WORKDIR /lambda
 
 ADD requirements.txt /tmp
 RUN pip install --quiet -t /lambda -r /tmp/requirements.txt && \
+    rm -f /lambda/setuptools/command/launcher\ manifest.xml && \
+    rm -f /lambda/setuptools/script\ \(dev\).tmpl && \
     find /lambda -type d | xargs chmod ugo+rx && \
     find /lambda -type f | xargs chmod ugo+r
 

--- a/src/provider.py
+++ b/src/provider.py
@@ -2,8 +2,9 @@ import logging
 import certificate_dns_record_provider
 import certificate_provider
 import issued_certificate_provider
+from os import getenv
 
-logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+logging.basicConfig(level=getenv("LOG_LEVEL", "INFO"))
 
 
 def handler(request, context):


### PR DESCRIPTION
The docker image build fails with the following error:
chmod: cannot access '/lambda/setuptools/command/launcher': No such file or directory
chmod: cannot access 'manifest.xml': No such file or directory
chmod: cannot access '/lambda/setuptools/script': No such file or directory
chmod: cannot access '(dev).tmpl': No such file or directory

This is because xargs chokes on the entries highlighted below: 

... abbreviated content of /lambda/setuptools in docker image
-rw-r--r-- 1 root root  1195 Mar 20 10:02 py33compat.py
-rw-r--r-- 1 root root 14276 Mar 20 10:02 sandbox.py
**-rw-r--r-- 1 root root   218 Mar 20 10:02 script (dev).tmpl**
-rw-r--r-- 1 root root   138 Mar 20 10:02 script.tmpl
-rw-r--r-- 1 root root  2302 Mar 20 10:02 site-patch.py
-rw-r--r-- 1 root root  8493 Mar 20 10:02 ssl_support.py
...

... abbreviated content of /lambda/setuptools/command in docker image
-rw-r--r-- 1 root root  2203 Mar 20 10:02 install_egg_info.py
-rw-r--r-- 1 root root  3840 Mar 20 10:02 install_lib.py
-rw-r--r-- 1 root root  2439 Mar 20 10:02 install_scripts.py
**-rw-r--r-- 1 root root   628 Mar 20 10:02 launcher manifest.xml**
-rw-r--r-- 1 root root  4986 Mar 20 10:02 py36compat.py
...

Removing both entries allows the build to run to completion

For provider.py, when the lambda is invoked Cloudwatch reports that the os package can't be found. Adding the import here fixes this

