### PR TITLE
Modernize AWS CFN commands to use 'deploy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ Checkout the sample in [cloudformation/demo-stack.yaml](cloudformation/demo-stac
 To install this custom resource, type:
 
 ```sh
-aws cloudformation create-stack \
-	--capabilities CAPABILITY_IAM \
+aws cloudformation deploy \
+        --capabilities CAPABILITY_IAM \
 	--stack-name cfn-certificate-provider \
-	--template-body file://cloudformation/cfn-resource-provider.yaml 
-
-aws cloudformation wait stack-create-complete  --stack-name cfn-certificate-provider 
+	--template-file cloudformation/cfn-resource-provider.yaml
 ```
 
 This CloudFormation template will use our pre-packaged provider from `s3://binxio-public-${AWS_REGION}/lambdas/cfn-certificate-provider-0.2.4.zip`.
@@ -46,10 +44,8 @@ To install the simple sample of the Custom Resource, type:
 ```sh
 read -p "domain name: " DOMAIN_NAME
 read -p "hosted zone id: " HOSTED_ZONE
-aws cloudformation create-stack --stack-name cfn-certificate-provider-demo \
-	--template-body file://cloudformation/demo-stack.yaml \
-	--parameters ParameterKey=DomainName,ParameterValue=$DOMAIN_NAME \
-		     ParameterKey=HostedZoneId,ParameterValue=$HOSTED_ZONE
-aws cloudformation wait stack-create-complete  --stack-name cfn-certificate-provider-demo
+aws cloudformation deploy --stack-name cfn-certificate-provider-demo \
+	--template-file cloudformation/demo-stack.yaml \
+	--parameter-overrides DomainName=$DOMAIN_NAME HostedZoneId=$HOSTED_ZONE
 ```
 


### PR DESCRIPTION
Simplification using the newer `deploy` subcommand of the aws cli