### PR TITLE
add CFNCustomProviderLogGroup

### DIFF
--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -54,6 +54,13 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
+  CFNCustomProviderLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn:
+      - CFNCustomProvider
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${CFNCustomProvider}
+      RetentionInDays: 7
   CFNCustomProvider:
     Type: AWS::Lambda::Function
     DependsOn:


### PR DESCRIPTION
Add LogGroup for CFNCustomProvider Lambda Function, so that the LogGroup will also be removed when you remove the CloudFormation Stack.