### PR TITLE
Support setting SubjectAlternativeNames

### DIFF
--- a/docs/Certificate.md
+++ b/docs/Certificate.md
@@ -12,6 +12,8 @@ To declare this entity in your AWS CloudFormation template, use the same syntax 
     Type: Custom::Certificate
     Properties:
       DomainName: !Ref DomainName
+      SubjectAlternativeNames:
+      - !Join ["", ["*.", !Ref DomainName]]
       ValidationMethod: DNS
       ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-certificate-provider'
 ```
@@ -20,6 +22,7 @@ To declare this entity in your AWS CloudFormation template, use the same syntax 
 You can specify the following properties:
 
     "DomainName" - to create a certificate for (required).
+    "SubjectAlternativeNames" - additional FQDNs to be included in the Subject Alternative Name extension of the ACM certificate. (optional).
     "ValidationMethod" - to validate the certificate with (required to be DNS).
     "ServiceToken" - pointing to the function implementing this resource (required).
     "Region" - region name where the certificate should be created, e.g. "us-east-1" (optional).

--- a/src/certificate_provider.py
+++ b/src/certificate_provider.py
@@ -35,6 +35,10 @@ class CertificateProvider(ResourceProvider):
                     "enum": ["DNS"],
                     "description": "to get the DNS validation record for",
                 },
+                "SubjectAlternativeNames": {
+                    "type": "array",
+                    "description": "Additional FQDNs to be included in the Subject Alternative Name extension of the ACM certificate.",
+                },
             },
         }
 
@@ -73,6 +77,8 @@ class CertificateProvider(ResourceProvider):
         try:
             if "DomainName" in changed_properties:
                 return self.request_certificate()
+            elif "SubjectAlternativeNames" in changed_properties:
+                return self.request_certificate()
             elif (
                 changed_properties
                 and len(changed_properties) == 1
@@ -89,7 +95,7 @@ class CertificateProvider(ResourceProvider):
                     self.fail("{}".format(error))
             elif changed_properties:
                 self.fail(
-                    'You can only change the "Options" and "DomainName" '
+                    'You can only change the "Options", "SubjectAlternativeNames" and "DomainName" '
                     + "of a certificate, you tried to change {}".format(
                         ", ".join(changed_properties)
                     )


### PR DESCRIPTION
I needed it for creating a wildcard certificate. Check it out - it's necessary to support.