### PR TITLE
chore: update lambda runtime as python 3.6 has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Deprecation notice 
-Almost two years after the release of this custom provider,  AWS finally provides native support for 
-creating certificates with CloudFormation without manual intervention. Checkout 
+# Deprecation notice
+Almost two years after the release of this custom provider,  AWS finally provides native support for
+creating certificates with CloudFormation without manual intervention. Checkout
 https://aws.amazon.com/blogs/security/how-to-use-aws-certificate-manager-with-aws-cloudformation/
 
 So, it is highly likely you do not need  this  custom provider anymore.
@@ -13,7 +13,7 @@ When you are creating immutable infrastructure, the email validation method is a
 human intervention. The DNS validation is of course the way to go! With 'Route53' we have full
 control over the DNS domain and can create the required records.
 
-Although the CloudFormation [AWS::CertificateManager::Certificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html) resource allow you to specify that you want DNS validation, it did not 
+Although the CloudFormation [AWS::CertificateManager::Certificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html) resource allow you to specify that you want DNS validation, it did not
 reveal the DNS records that you need to create. It writes them in the CloudFormation log
 file so that another human has to collect them and manually update the DNS record.
 
@@ -27,7 +27,7 @@ you can fully automate the provisioning of certificates, with the following reso
 
 1. [Custom::Certificate](docs/Certificate.md) to request a certificate without waiting for it to be issued
 3. [Custom::CertificateDNSRecord](docs/CertificateDNSRecord.md) which will obtain the DNS record for a domain name on the certificate.
-3. [Custom::IssuedCertificate](docs/IssuedCertificate.md) which will activately wait until the certificate is issued.
+3. [Custom::IssuedCertificate](docs/IssuedCertificate.md) which will actively wait until the certificate is issued.
 4. [AWS::Route53::ResourceRecordSet](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html) to create the validation DNS record.
 
 Checkout the sample in [cloudformation/demo-stack.yaml](cloudformation/demo-stack.yaml).

--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -5,43 +5,42 @@ Parameters:
   S3BucketName:
     Type: String
     Default: ''
+
   S3BucketPrefix:
     Type: String
     Default: 'binxio-public'
+
   CFNCustomProviderZipFileName:
     Type: String
     Default: 'lambdas/cfn-certificate-provider-0.2.5.zip'
+
 Conditions:
   UseBucketName: !Not [!Equals [!Ref S3BucketName, ""]]
+
 Resources:
   LambdaPolicy:
     Type: AWS::IAM::Policy
-    DependsOn:
-      - LambdaRole
     Properties:
       PolicyName: CFNCertificateDomainResourceRecordProvider
+      Roles:
+        - !Ref 'LambdaRole'
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
               - acm:RequestCertificate
+            Resource: '*'
+          - Effect: Allow
+            Action:
               - acm:DescribeCertificate
               - acm:UpdateCertificateOptions
               - acm:DeleteCertificate
-            Resource:
-            - '*'
+            Resource: !Sub arn:aws:acm:*:${AWS::AccountId}:certificate/*
           - Effect: Allow
-            Action:
-            - lambda:InvokeFunction
-            Resource:
-            - !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-certificate-provider'
-          - Effect: Allow
-            Action:
-              - logs:*
-            Resource: arn:aws:logs:*:*:*
-      Roles:
-        - !Ref 'LambdaRole'
+            Action: lambda:InvokeFunction
+            Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-certificate-provider'
+
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -54,17 +53,25 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/binxio-cfn-certificate-provider:*
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+
   CFNCustomProviderLogGroup:
     Type: AWS::Logs::LogGroup
-    DependsOn:
-      - CFNCustomProvider
     Properties:
       LogGroupName: !Sub /aws/lambda/${CFNCustomProvider}
       RetentionInDays: 7
+
   CFNCustomProvider:
     Type: AWS::Lambda::Function
-    DependsOn:
-      - LambdaRole
     Properties:
       Description: CFN Certificate Domain Resource Record Provider
       Code:
@@ -74,5 +81,5 @@ Resources:
       Handler: provider.handler
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300


### PR DESCRIPTION
I tested the provider with the latest version and it works fine on 3.9. I also tweaked the policies a bit so that they cause less noise when cfn_nag is used and making them more specific.